### PR TITLE
support deep filtering, enhance api to find components or dom nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.1",
   "description": "Expose react internals for E2E testing",
   "main": "index.js",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "lodash.ismatch": "^4.1.1"
+  }
 }


### PR DESCRIPTION
Hey @fgnass,
I extended the filter to support deep matching. I was to lazy implementing this by myself, so I decided to use lodash for this. I also extended the retractor api a little bit to support component and DOM lookups, see:
- `findAllComponents`
- `findOneComponent`
- `findAllDOMNodes`
- `findOneDOMNode`

How do you like this proposal?
regards Andreas